### PR TITLE
Deploy site to GitHub Pages + fix subpath asset/link bugs

### DIFF
--- a/.github/workflows/generate-event-auto-commit.yml
+++ b/.github/workflows/generate-event-auto-commit.yml
@@ -1,0 +1,48 @@
+name: Generate event (auto-commit)
+
+# Fully-automatic alternative to generate-event-pr.yml — commits the
+# generated event page (with its social_post frontmatter) straight to
+# master, which kicks off gh-pages.yml to deploy it, then post-to-socials.yml
+# posts to Mastodon + Slack once that deploy succeeds.
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "0 18 * * 2" # Tuesdays, noon MDT / 11am MST (cron can't follow DST)
+
+permissions:
+  contents: write
+
+jobs:
+  generate-event-auto-commit:
+    runs-on: ubuntu-latest
+    env:
+      AI_PROVIDER: ${{ vars.AI_PROVIDER }}
+      AI_MODEL: ${{ vars.AI_MODEL }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+      MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Generate next event page
+        id: generate
+        run: ruby script/generate_event.rb --mode=direct
+
+      - name: Commit and push
+        if: steps.generate.outputs.event_file != ''
+        env:
+          EVENT_DATE: ${{ steps.generate.outputs.event_date }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/_events/*.md
+          git diff --cached --quiet && exit 0
+          git commit -m "Add upcoming event page ($EVENT_DATE)"
+          git push

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,56 @@
+name: Deploy to GitHub pages
+
+on:
+  push:
+    branches:
+      - master
+      - feature/gh-automation-for-auto-event-generation # TODO: remove this after testing
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "yarn"
+      - run: yarn install
+
+      - name: Build
+        env:
+          BRIDGETOWN_ENV: production
+        run: bin/bridgetown deploy
+
+      - name: Upload build artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./output
+
+  deploy:
+    needs: build
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "yarn"
       - run: yarn install
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - feature/gh-automation-for-auto-event-generation # TODO: remove this after testing
 
 concurrency:
   group: pages

--- a/.github/workflows/post-to-socials.yml
+++ b/.github/workflows/post-to-socials.yml
@@ -1,0 +1,47 @@
+name: Post to socials
+
+# Runs after the site has deployed. If the deployed commit added or changed
+# an event page, posts that page's `social_post` frontmatter to Mastodon + Slack.
+
+on:
+  workflow_run:
+    workflows: ["Deploy to GitHub pages"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  post-to-socials:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    env:
+      SLACK_API_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
+      SLACK_CHANNELS: ${{ vars.SLACK_CHANNELS }}
+      MASTODON_API_TOKEN: ${{ secrets.MASTODON_API_TOKEN }}
+      MASTODON_BASE_URL: ${{ vars.MASTODON_BASE_URL }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Find changed event pages
+        id: changed
+        run: |
+          files=$(git diff --name-only HEAD~1 HEAD -- 'src/_events/*.md' || true)
+          echo "files<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$files" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Post to Mastodon + Slack
+        if: steps.changed.outputs.files != ''
+        run: |
+          echo "${{ steps.changed.outputs.files }}" | while IFS= read -r file; do
+            [ -n "$file" ] && ruby script/publish_social_post.rb "$file"
+          done

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ task default: :deploy
 # Standard set of tasks, which you can customize if you wish:
 #
 desc "Build the Bridgetown site for deployment"
-task :deploy => [:clean, "frontend:build"] do
+task deploy: [:clean, "frontend:build"] do
   Bridgetown::Commands::Build.start
 end
 

--- a/bridgetown.config.yml
+++ b/bridgetown.config.yml
@@ -22,12 +22,13 @@ url: "" # the base hostname & protocol for your site, e.g. https://example.com
 permalink: pretty
 template_engine: erb
 
-# Other options you might want to investigate:
-#
-# base_path: "/" # the subpath of your site, e.g. /blog. If you set this option,
-# ensure you use the `relative_url` helper for all links and assets in your HTML.
-# If you're using esbuild for frontend assets, edit `esbuild.config.js` to
-# update `publicPath`.
+# NOTE: Set because this repo is currently deployed as a GitHub Pages *project* site
+# under github.com/mhakeem (mhakeem.github.io/bouldercodencoffee.github.io/)
+# rather than at a domain root.
+# TODO: Remove this (and the matching `publicPath` in
+# esbuild.config.js) once the repo is owned by an org/user actually named
+# bouldercodencoffee, where GitHub Pages serves it at the true root.
+base_path: "/bouldercodencoffee.github.io"
 
 collections:
   events:

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -32,6 +32,7 @@ const build = require("./config/esbuild.defaults.js")
  * @type {BuildOptions}
  */
 const esbuildOptions = {
+  publicPath: "/bouldercodencoffee.github.io/_bridgetown/static",
   plugins: [
     // add new plugins here...
   ],

--- a/src/_components/shared/navbar.erb
+++ b/src/_components/shared/navbar.erb
@@ -2,7 +2,7 @@
   <div class="container mx-auto px-4 py-4">
     <div class="flex items-center justify-between">
       <h1 class="text-2xl md:text-3xl font-display font-bold flex items-center">
-        <a href="/">
+        <a href="<%= relative_url "/" %>">
           <i class="fas fa-coffee mr-2 text-coffee"></i>
           <i class="fas fa-code mr-2 text-code"></i>
           <span class="bg-clip-text text-transparent bg-gradient-to-r from-coffee to-code">
@@ -13,10 +13,10 @@
       <div class="flex items-center">
         <nav id="main-menu" class="hidden md:block absolute md:relative left-0 right-0 top-full md:top-auto bg-white md:bg-transparent shadow-md md:shadow-none">
           <ul class="flex flex-col md:flex-row md:space-x-8 text-lg container mx-auto px-4 py-4 md:p-0">
-            <li class="mb-2 md:mb-0"><a href="/" class="block text-coffee hover:text-code transition duration-300">Home</a></li>
-            <li class="mb-2 md:mb-0"><a href="/events" class="block text-coffee hover:text-code transition duration-300">Events</a></li>
+            <li class="mb-2 md:mb-0"><a href="<%= relative_url "/" %>" class="block text-coffee hover:text-code transition duration-300">Home</a></li>
+            <li class="mb-2 md:mb-0"><a href="<%= relative_url "/events" %>" class="block text-coffee hover:text-code transition duration-300">Events</a></li>
             <li class="mb-2 md:mb-0">
-              <a href="/feed/events.xml" class="block text-coffee hover:text-code transition duration-300">
+              <a href="<%= relative_url "/feed/events.xml" %>" class="block text-coffee hover:text-code transition duration-300">
                 <i class="fa-solid fa-square-rss text-2xl"></i>
               </li>
             </a>

--- a/src/_partials/_footer.erb
+++ b/src/_partials/_footer.erb
@@ -14,7 +14,7 @@
         <a href="https://ruby.social/@codencoffee" class="text-coffee-light hover:text-white transition duration-300">
           <i class="fab fa-mastodon text-2xl"></i>
         </a>
-        <a href="/feed/events.xml" class="text-coffee-light hover:text-white transition duration-300">
+        <a href="<%= relative_url "/feed/events.xml" %>" class="text-coffee-light hover:text-white transition duration-300">
           <i class="fa-solid fa-square-rss text-2xl"></i>
         </a>
       </div>

--- a/src/index.erb
+++ b/src/index.erb
@@ -12,7 +12,9 @@ layout: default
   </div>
 </div>
 
-<%= render "event", event: collections.events.resources.last %>
+<% if (upcoming_event = collections.events.resources.last) %>
+  <%= render "event", event: upcoming_event %>
+<% end %>
 
 <div class="bg-gray-100 py-16">
   <div class="container mx-auto px-4">


### PR DESCRIPTION
This PR wires up GitHub Pages deployment for the site and the two workflows that depend on it (event generation auto-commit, and posting to socials after a successful deploy), plus fixes a couple of bugs that only showed up once actually deployed.

Changes Made:

- Added gh-pages.yml to build and deploy the site to GitHub Pages via GitHub Actions on push to master
- Added generate-event-auto-commit.yml, a scheduled (Tuesdays ~noon Mountain) + manually-dispatchable workflow that runs generate_event.rb and commits the resulting event page straight to master
- Added post-to-socials.yml, which fires via workflow_run once gh-pages.yml deploys successfully, diffs the deployed commit for changed event pages, and posts each one's social_post frontmatter to Mastodon/Slack
- Fixed a NoMethodError crash in index.erb when the events collection is empty (no event pages yet) by nil-guarding the "render latest event" call
- Fixed unstyled/broken asset and internal link URLs on GitHub Pages project-page (subpath) deployments by adding base_path to bridgetown.config.yml + matching publicPath to esbuild.config.js, and switching hardcoded href="/..." links in navbar.erb/_footer.erb to use relative_url